### PR TITLE
メニュー展開時、ネストがある場合に展開するためのボタンが、↓のところしかタップできない #55

### DIFF
--- a/scss/modules/_header.scss
+++ b/scss/modules/_header.scss
@@ -190,10 +190,14 @@
       }
     }
     .dropdown-toggle {
+      width: 100%;
+      height: 100%;
       color: $color-white;
-      right: 7.6923%;
-      top: 15px;
       &:after {
+        position: absolute;
+        top: 30px;
+        right: 7.6923%;
+        left: auto;
         border: none;
         width: auto;
       }


### PR DESCRIPTION
ローカル環境で実機と同期できなかったため、まだ、実機では未検証です...すいません。
